### PR TITLE
Remove statseg entries when renaming interface

### DIFF
--- a/vpp-patches/0010-Rename-interface-statseg.patch
+++ b/vpp-patches/0010-Rename-interface-statseg.patch
@@ -1,0 +1,113 @@
+From dd8e378ff5bbb26573d29024ea68f4d1010c449b Mon Sep 17 00:00:00 2001
+From: Sergey Matov <sergey.matov@travelping.com>
+Date: Mon, 23 May 2022 16:06:55 +0400
+Subject: [PATCH] Rename statseg interface
+
+---
+ src/vnet/interface.c         |  3 +++
+ src/vnet/vnet.h              |  1 +
+ src/vpp/stats/stat_segment.c | 42 ++++++++++++++++++++++++++++++++++++
+ src/vpp/stats/stat_segment.h |  2 ++
+ 4 files changed, 48 insertions(+)
+
+diff --git a/src/vnet/interface.c b/src/vnet/interface.c
+index 412c6755e..6d472232f 100644
+--- a/src/vnet/interface.c
++++ b/src/vnet/interface.c
+@@ -1581,6 +1581,9 @@ vnet_rename_interface (vnet_main_t * vnm, u32 hw_if_index, char *new_name)
+   vlib_node_rename (vm, hw->tx_node_index, "%v-tx", hw->name);
+   vlib_node_rename (vm, hw->output_node_index, "%v-output", hw->name);
+ 
++  /* rename statseg directory */
++  statseg_interface_rename (hw);
++
+   /* free the old name vector */
+   vec_free (old_name);
+ 
+diff --git a/src/vnet/vnet.h b/src/vnet/vnet.h
+index 227fa5be3..1ca923cdd 100644
+--- a/src/vnet/vnet.h
++++ b/src/vnet/vnet.h
+@@ -50,6 +50,7 @@
+ #include <vnet/config.h>
+ #include <vnet/interface.h>
+ #include <vnet/api_errno.h>
++#include <vpp/stats/stat_segment.h>
+ 
+ /* ip table add delete callback */
+ typedef struct _vnet_ip_table_function_list_elt
+diff --git a/src/vpp/stats/stat_segment.c b/src/vpp/stats/stat_segment.c
+index c20ecfc6a..04154e6d6 100644
+--- a/src/vpp/stats/stat_segment.c
++++ b/src/vpp/stats/stat_segment.c
+@@ -1009,6 +1009,48 @@ statseg_config (vlib_main_t * vm, unformat_input_t * input)
+ 
+ VLIB_EARLY_CONFIG_FUNCTION (statseg_config, "statseg");
+ 
++clib_error_t *
++statseg_interface_rename (vnet_hw_interface_t *hw)
++{
++  u32 sw_if_index = hw->sw_if_index;
++  stat_segment_main_t *sm = &stat_segment_main;
++  stat_segment_directory_entry_t *ep;
++  void *oldheap = vlib_stats_push_heap (sm->interfaces);
++  u8 *s = 0;
++  u8 *symlink_new_name = 0;
++  u8 *symlink_name = 0;
++  u32 vector_index;
++
++  vlib_stat_segment_lock ();
++
++  s = format (s, "%v%c", hw->name, '\0');
++
++#define _(E, n, p)                                                      \
++  vec_reset_length (symlink_name);                                            \
++  symlink_name = format (symlink_name, "/interfaces/%U/" #n "%c",               \
++                         format_vlib_stats_symlink, sm->interfaces[sw_if_index], 0);  \
++  clib_mem_set_heap (oldheap); /* Exit stats segment */                       \
++  vector_index = lookup_hash_index ((u8 *) symlink_name);                     \
++  clib_mem_set_heap (sm->heap); /* Re-enter stat segment */                   \
++  vec_reset_length (symlink_new_name);                                        \
++  symlink_new_name = format (symlink_new_name, "/interfaces/%U/" #n "%c",       \
++                             format_vlib_stats_symlink, s, 0);                \
++  vlib_stats_rename_symlink (oldheap, vector_index, symlink_new_name);
++      foreach_simple_interface_counter_name
++        foreach_combined_interface_counter_name
++#undef _
++
++  vec_free (symlink_new_name);
++  vec_free (symlink_name);
++  sm->interfaces[sw_if_index] = s;
++  ep = &sm->directory_vector[STAT_COUNTER_INTERFACE_NAMES];
++  ep->data = sm->interfaces;
++
++  vlib_stat_segment_unlock ();
++  clib_mem_set_heap (oldheap);
++  return 0;
++}
++
+ static clib_error_t *
+ statseg_sw_interface_add_del (vnet_main_t * vnm, u32 sw_if_index, u32 is_add)
+ {
+diff --git a/src/vpp/stats/stat_segment.h b/src/vpp/stats/stat_segment.h
+index f5862a684..6878e0c41 100644
+--- a/src/vpp/stats/stat_segment.h
++++ b/src/vpp/stats/stat_segment.h
+@@ -19,6 +19,7 @@
+ #include <vlib/vlib.h>
+ #include <vppinfra/socket.h>
+ #include <vpp/stats/stat_segment_shared.h>
++#include <vnet/vnet.h>
+ 
+ typedef enum
+ {
+@@ -119,5 +120,6 @@ void vlib_stats_register_symlink (void *oldheap, u8 *name, u32 index1,
+ 				  u32 index2, u8 lock);
+ 
+ void stat_provider_register_vector_rate (u32 num_workers);
++clib_error_t * statseg_interface_rename (vnet_hw_interface_t *hw);
+ 
+ #endif
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
Rename name of the interface within stats segment if the interface has been renamed via CLI or binapi.