### PR TITLE
Adjust the CI environment

### DIFF
--- a/hack/ci-build.sh
+++ b/hack/ci-build.sh
@@ -7,7 +7,6 @@ set -o errtrace
 : ${REGISTRY:=quay.io}
 : ${IMAGE_NAME:=travelping/upg-vpp}
 : ${DOCKERFILE:=}
-: ${BUILDKITD_ADDR:=tcp://buildkitd:1234}
 : ${BUILD_TYPE:=debug}
 : ${NO_PUSH:=}
 : ${IMAGE_EXPIRES_AFTER:=}
@@ -31,7 +30,7 @@ function do_build {
     opts+=(--opt label:quay.expires-after="${IMAGE_EXPIRES_AFTER}")
   fi
   set -x
-  buildctl --addr "${BUILDKITD_ADDR}" build "${opts[@]}" "$@"
+  buildctl build "${opts[@]}" "$@"
   set +x
 }
 


### PR DESCRIPTION
Rely on BUILDKIT_HOST env var for the buildkitd address