### PR TITLE
[CENNSO-77][NAT] Write log if CGNAT can't make a translation

### DIFF
--- a/vpp-patches/0015-NAT-Add-logging-if-NAT-can-t-perform-a-translation.patch
+++ b/vpp-patches/0015-NAT-Add-logging-if-NAT-can-t-perform-a-translation.patch
@@ -1,0 +1,49 @@
+From 8825682831c7da7fe1dd95faa77411b9730a3905 Mon Sep 17 00:00:00 2001
+From: Sergey Matov <sergey.matov@travelping.com>
+Date: Fri, 18 Nov 2022 15:43:00 +0400
+Subject: [PATCH] [NAT] Add logging if NAT can't perform a translation
+
+---
+ src/plugins/nat/nat44-ed/nat44_ed.c        | 2 +-
+ src/plugins/nat/nat44-ed/nat44_ed_in2out.c | 5 ++++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/nat/nat44-ed/nat44_ed.c b/src/plugins/nat/nat44-ed/nat44_ed.c
+index 1e2b636a3..fb2d3edc2 100644
+--- a/src/plugins/nat/nat44-ed/nat44_ed.c
++++ b/src/plugins/nat/nat44-ed/nat44_ed.c
+@@ -2313,7 +2313,7 @@ nat_init (vlib_main_t * vm)
+ 
+   nat44_set_node_indexes (sm, vm);
+ 
+-  sm->log_class = vlib_log_register_class ("nat", 0);
++  sm->log_class = vlib_log_register_class_rate_limit ("nat", 0, 1);
+   nat_ipfix_logging_init (vm);
+ 
+   nat_init_simple_counter (sm->total_sessions, "total-sessions",
+diff --git a/src/plugins/nat/nat44-ed/nat44_ed_in2out.c b/src/plugins/nat/nat44-ed/nat44_ed_in2out.c
+index 4b3969bdb..e2eefa1f5 100644
+--- a/src/plugins/nat/nat44-ed/nat44_ed_in2out.c
++++ b/src/plugins/nat/nat44-ed/nat44_ed_in2out.c
+@@ -211,6 +211,9 @@ nat_controlled_alloc_addr_and_port (snat_main_t * sm,
+   while (attempts > 0);
+ 
+   /* Totally out of translations to use... */
++  nat_log_warn ("Out of ports for binding %U:%u-%u",
++		format_ip4_address, &bn->external_addr,
++		bn->start_port, bn->end_port);
+   return 1;
+ }
+ 
+@@ -464,7 +467,7 @@ slow_path_ed (vlib_main_t *vm, snat_main_t *sm, vlib_buffer_t *b,
+ 	  b->error = node->errors[NAT_IN2OUT_ED_ERROR_MAX_SESSIONS_EXCEEDED];
+ 	  nat_ipfix_logging_max_sessions (thread_index,
+ 					  sm->max_translations_per_thread);
+-	  nat_elog_notice (sm, "maximum sessions exceeded");
++	  nat_log_warn ("maximum sessions exceeded");
+ 	  return NAT_NEXT_DROP;
+ 	}
+     }
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
- Log if NAT can't allocate port for given binding to make a translation
- Log if NAT flows table is full
- Set NAT logs rate limit to 1 message per second.