### PR TITLE
[CENNSO-148] Use clang-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=private \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential sudo git netbase curl ca-certificates \
     ${GO_PACKAGE} iproute2 gdb tcpdump iputils-ping libpcap-dev \
-    dumb-init gdbserver clang-9 && \
+    dumb-init gdbserver clang-11 && \
     curl -sSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" | \
     tar -xvz -C /usr/local bin/buildctl && \
     echo "${BUILDCTL_SHA256}  /usr/local/bin/buildctl" | sha256sum -c && \

--- a/vpp-patches/0030-test-fix-import-in-vpp_ipsec.py.patch
+++ b/vpp-patches/0030-test-fix-import-in-vpp_ipsec.py.patch
@@ -1,0 +1,23 @@
+From e9334e5f1b5a249e0a85adeaf8cd337b504ab8ab Mon Sep 17 00:00:00 2001
+From: Ivan Shvedunov <ivan.shvedunov@travelping.com>
+Date: Fri, 20 Oct 2023 04:01:30 +0400
+Subject: [PATCH] test: fix import in vpp_ipsec.py
+
+Type: fix
+Signed-off-by: Ivan Shvedunov <ivan4th@gmail.com>
+---
+ test/vpp_ipsec.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/test/vpp_ipsec.py b/test/vpp_ipsec.py
+index eb0209fc5..4030de6c1 100644
+--- a/test/vpp_ipsec.py
++++ b/test/vpp_ipsec.py
+@@ -1,3 +1,4 @@
++import socket
+ from vpp_object import VppObject
+ from ipaddress import ip_address
+ from vpp_papi import VppEnum
+-- 
+2.40.0
+


### PR DESCRIPTION
Building UPG-VPP against VPP 22.10 requires clang-11