### PR TITLE
[CENNSO-2138] Upgrade golang to fetch security fixes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,8 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on:
+    - ubuntu-22.04
     strategy:
       matrix:
         build_type: [debug, release]
@@ -56,7 +57,8 @@ jobs:
 
   # dummy job for release.yaml to wait on
   conclude:
-    runs-on: ["self-hosted"]
+    runs-on:
+    - ubuntu-22.04
     needs:
     - build
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV BUILDCTL_SHA256 "b64aec46fb438ea844616b3205c33b01a3a49ea7de1f8539abd0daeb4f0
 ENV INDENT_SHA256 "12185be748db620f8f7799ea839f0d10ce643b9f5ab1805c960e56eb27941236"
 ENV LIBC_SHA256 "9a8caf9f33448a8f2f526e94d00c70cdbdd735caec510df57b3283413df7882a"
 # Go version in ppa:longsleep/golang-backports
-ENV GO_PACKAGE "golang-1.18-go"
+ENV GO_PACKAGE "golang-1.22-go"
 
 COPY vpp/Makefile /vpp-src/Makefile
 COPY vpp/build/external /vpp-src/build/external
@@ -43,8 +43,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=private \
     make UNATTENDED=yes install-dep install-ext-dep && \
     apt-get clean && \
     rm -rf /vpp-src && \
-    ln -s /usr/lib/go-1.18/bin/go /usr/bin/go && \
-    ln -s /usr/lib/go-1.18/bin/gofmt /usr/bin/gofmt
+    ln -s /usr/lib/go-1.22/bin/go /usr/bin/go && \
+    ln -s /usr/lib/go-1.22/bin/gofmt /usr/bin/gofmt
 
 ENV GOPATH /go
 
@@ -116,7 +116,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=private \
     libhyperscan5 libmbedcrypto3 libmbedtls12 libmbedx509-0 apt-utils \
     libpython3-stdlib \
     python3 python3-minimal python3.6 python3-minimal \
-    python3-cffi python3-cffi-backend libnuma1
+    python3-cffi python3-cffi-backend libnuma1 \
+    libnl-3-200 libnl-route-3-200 libpcap0.8
 
 RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=private \
     --mount=target=/var/cache/apt,type=cache,sharing=private \

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ to implement the required Mobile Core User Plane Function (UPF) features:
 ## Usage
 
 FPP VPP provides a [`Dockerfile`](./Dockerfile) that creates an Ubuntu image with the installed patched VPP version.
-FPP VPP is currently based on VPP version `stable/2202`.
+FPP VPP is currently based on VPP version `stable/2210`.
 
 Build images are stored in the [Travelping's quay](https://quay.io/repository/travelping/fpp-vpp?tab=tags) repository.
 
 ### Build versioning
 
-For the most stable FPP VPP version, use the release images tagged with the `v22.02.1_release` naming schema.
-Image tagging uses the following convention: `v<vpp-release>.<internal-build>`. For example, `v22.02.1` means that the VPP base version is `22.02`, and `.1` is the internal build number.
+For the most stable FPP VPP version, use the release images tagged with the `v22.10.1_release` naming schema.
+Image tagging uses the following convention: `v<vpp-release>.<internal-build>`. For example, `v22.10.1` means that the VPP base version is `22.10`, and `.1` is the internal build number.
 
 ### Run the built image
 
@@ -53,7 +53,7 @@ To add a patch to FPP VPP, follow these steps:
 
 1. Run the `hack/update-app.sh` script to download sources and downstream patches stored in the `vpp-patches` folder.
 1. Provide changes to the code in the `vpp` directory and commit the output to git.
-1. Create a patch using this command: 
+1. Create a patch using this command:
     ```
     git format-patch -N -1 HEAD
     ```


### PR DESCRIPTION
Update golang to 1.22.4 (latest) version to fix security issues