### PR TITLE
[CEP-148] fix: load_balance_pool not taking barrier on removal

### DIFF
--- a/vpp-patches/0032-fix-load_balance_pool-not-taking-barrier-on-removal.patch
+++ b/vpp-patches/0032-fix-load_balance_pool-not-taking-barrier-on-removal.patch
@@ -1,0 +1,41 @@
+From d8651bdf338731f2c76b0d431618e9477096bd2d Mon Sep 17 00:00:00 2001
+From: Vladimir Zhigulin <vladimir.jigulin@travelping.com>
+Date: Tue, 29 Apr 2025 19:07:30 +0200
+Subject: [PATCH] fix load_balance_pool not taking barrier on removal
+
+---
+ src/vnet/dpo/load_balance.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/vnet/dpo/load_balance.c b/src/vnet/dpo/load_balance.c
+index 8f2a0de6e..a02a7854e 100644
+--- a/src/vnet/dpo/load_balance.c
++++ b/src/vnet/dpo/load_balance.c
+@@ -894,6 +894,9 @@ load_balance_destroy (load_balance_t *lb)
+ {
+     dpo_id_t *buckets;
+     int i;
++    u8 need_barrier_sync;
++    vlib_main_t *vm = vlib_get_main();
++    ASSERT (vm->thread_index == 0);
+ 
+     buckets = load_balance_get_buckets(lb);
+ 
+@@ -911,7 +914,14 @@ load_balance_destroy (load_balance_t *lb)
+     fib_urpf_list_unlock(lb->lb_urpf);
+     load_balance_map_unlock(lb->lb_map);
+ 
++    need_barrier_sync = pool_put_will_expand (load_balance_pool, lb);
++    if (need_barrier_sync)
++        vlib_worker_thread_barrier_sync (vm);
++
+     pool_put(load_balance_pool, lb);
++
++    if (need_barrier_sync)
++        vlib_worker_thread_barrier_release (vm);
+ }
+ 
+ static void
+-- 
+2.49.0
+


### PR DESCRIPTION
It was triggering false positive ASSERT in debug multithreaded environment